### PR TITLE
Source trap status effects from the system instead of a hardcoded allow-list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ scripts/main.js.bak
 .env.local
 /em-tile-utilities.lock
 /GITHUB-WORKFLOWS-AND-TESTING-GUIDE.md
+
+# Subagent git worktrees
+.claude/worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.2.1] - 2026-08-12
+
+### Fixed
+
+- **The trap effect list was missing twelve real D&D 5e conditions, and offered two that do not exist.** The list of status effects a trap can apply was a hardcoded allow-list, checked against the system's effects — so anything not written into that array was silently dropped from the dropdown. Against dnd5e 5.3.3 that meant **Dehydration, Falling, Inaudible, Malnutrition, Suffocation, Surprised** and **Transformed** could not be selected at all, along with the three cover levels (Half, Three-Quarters, Total). Meanwhile it offered "Slowed" and "Hasted", which are not D&D 5e conditions — they come from other modules, so those two entries never matched anything and never appeared. The list is now sourced from the system itself and the curated array only controls **ordering**: the effects a trap most often applies still sit at the top, and everything else the system defines appears below them. A condition added by a future D&D 5e release, or registered by another module, now shows up on its own.
+
 ## [2.2.0] - 2026-08-11
 
 A correctness release. Three features that appeared to work in the UI never actually did anything at the table — saving throws, trap damage under midi-qol, and the Reset tile — and this release fixes all three, along with the dnd5e 5.3.3 and Monk's Active Tiles 14.01 integration points that had silently drifted out of date.

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "em-tile-utilities",
   "title": "Dorman Lakely's Tile Utilities",
   "description": "Create interactive puzzles, traps, and environmental elements in seconds. Point-and-click tools for switches, pressure plates, lights, resets, and more—powered by Monk's Active Tiles.",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "compatibility": {
     "minimum": "14",
     "verified": "14"
@@ -65,7 +65,7 @@
   ],
   "url": "https://github.com/jesshmusic/em-tile-utilities",
   "manifest": "https://github.com/jesshmusic/em-tile-utilities/releases/latest/download/module.json",
-  "download": "https://github.com/jesshmusic/em-tile-utilities/releases/download/v2.2.0/module.zip",
+  "download": "https://github.com/jesshmusic/em-tile-utilities/releases/download/v2.2.1/module.zip",
   "hotReload": {
     "extensions": [
       "css",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "em-tile-utilities",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "A FoundryVTT module that provides utility tile creation tools for Monk's Active Tiles.",
   "main": "dist/main.js",
   "scripts": {

--- a/src/dialogs/trap-dialog.ts
+++ b/src/dialogs/trap-dialog.ts
@@ -11,7 +11,8 @@ import {
   getItemActivities,
   extractTrapActivityData,
   getDamageTypeOptions,
-  DEFAULT_DAMAGE_TYPE
+  DEFAULT_DAMAGE_TYPE,
+  getStatusEffectOptions
 } from '../utils/helpers';
 import type { TrapActivityData } from '../utils/helpers';
 import { getActiveTileManager } from './tile-manager-state';
@@ -297,65 +298,11 @@ export class TrapDialog extends HandlebarsApplicationMixin(ApplicationV2) {
       { value: 'save:cha', label: 'EMPUZZLES.CharismaSave' }
     ];
 
-    // Prepare effect options (active effects from game system)
-    // Order by most common to least common for trap usage
-    // Only include core D&D 5e conditions and relevant trap effects (exclude MonksLittleDetails tracking effects)
-    const effectPriority = [
-      'poisoned',
-      'restrained',
-      'prone',
-      'blinded',
-      'frightened',
-      'stunned',
-      'paralyzed',
-      'incapacitated',
-      'grappled',
-      'deafened',
-      'charmed',
-      'slowed',
-      'exhaustion',
-      'burning',
-      'bleeding',
-      'unconscious',
-      'petrified',
-      'cursed',
-      'diseased',
-      'silenced',
-      'invisible',
-      'hasted',
-      'dead'
-    ];
-
-    const effectOptions: any[] = [];
-    const globalConfig = (globalThis as any).CONFIG;
-    if (globalConfig?.statusEffects) {
-      // Create a map of effects by ID (lowercase for case-insensitive matching)
-      const effectsMap = new Map<string, any>();
-      globalConfig.statusEffects.forEach((effect: any) => {
-        const id = (effect.id || effect.name || '').toLowerCase();
-        const label = effect.label || effect.name || '';
-
-        // Skip MonksLittleDetails effects (check both ID and label)
-        if (label.includes('MonksLittleDetails') || id.includes('monkslittledetails')) {
-          return;
-        }
-
-        // Only include effects in our priority list
-        if (effectPriority.includes(id)) {
-          effectsMap.set(id, {
-            value: effect.id || effect.name,
-            label: effect.label || effect.name
-          });
-        }
-      });
-
-      // Add effects in priority order
-      effectPriority.forEach(priorityId => {
-        if (effectsMap.has(priorityId)) {
-          effectOptions.push(effectsMap.get(priorityId));
-        }
-      });
-    }
+    // Status effects come from the system so this list cannot silently drift
+    // from dnd5e's — see src/utils/helpers/status-effects.ts, which orders the
+    // trap-relevant ones first and then appends everything else the system
+    // defines rather than filtering to a hardcoded allow-list.
+    const effectOptions = getStatusEffectOptions();
 
     // Damage types come from the system so this list cannot silently drift from
     // dnd5e's. Shared with the custom `em-tile-utilities.applydamage` Monk's

--- a/src/utils/helpers/index.ts
+++ b/src/utils/helpers/index.ts
@@ -3,6 +3,7 @@
  */
 
 export * from './damage-types';
+export * from './status-effects';
 export * from './dnd5e-activity';
 export * from './folder-helpers';
 export * from './grid-helpers';

--- a/src/utils/helpers/status-effects.ts
+++ b/src/utils/helpers/status-effects.ts
@@ -54,12 +54,33 @@ const TRAP_EFFECT_PRIORITY: readonly string[] = [
 ];
 
 /**
- * Effects that are bookkeeping rather than something a trap applies. Monk's
- * Little Details registers combat-tracker markers this way, and dnd5e's own
- * `concentrating` is managed by the system's concentration tracking — offering
- * them as trap effects is noise.
+ * Effects that are bookkeeping rather than something a trap applies.
+ *
+ * Note this is a *deny*-list, and that asymmetry is the point: it fails toward
+ * showing an unrecognised effect, where the allow-list this replaced failed
+ * toward hiding one. Keep it short, and only for effects a trap applying would
+ * be meaningless rather than merely unusual.
+ *
+ * Confirmed against the live world's rendered dropdown on Foundry 14.364:
+ * - `concentrating` is dnd5e's own, driven by the system's concentration
+ *   tracking.
+ * - `bonusaction` / `reaction` ("Bonus Action used", "Reaction used") are
+ *   action-economy markers cleared every turn, so a trap setting one is
+ *   erased almost immediately.
+ * - `flanking` / `flanked` are positional state recomputed from token
+ *   positions, so setting them by hand does not survive.
+ *
+ * Deliberately NOT excluded: `marked` is a real tactical condition some tables
+ * use, and dnd5e's own `encumbered` / `heavilyEncumbered` /
+ * `exceedingCarryingCapacity` are plausible trap effects.
  */
-const EXCLUDED_EFFECT_IDS: readonly string[] = ['concentrating'];
+const EXCLUDED_EFFECT_IDS: readonly string[] = [
+  'concentrating',
+  'bonusaction',
+  'reaction',
+  'flanking',
+  'flanked'
+];
 
 /** Effects whose id or label marks them as another module's internal tracking. */
 function isTrackingEffect(id: string, label: string): boolean {

--- a/src/utils/helpers/status-effects.ts
+++ b/src/utils/helpers/status-effects.ts
@@ -1,0 +1,110 @@
+/**
+ * Status effect options, sourced from the running system.
+ *
+ * Extracted from `TrapDialog#_prepareContext` for the same reason as
+ * src/utils/helpers/damage-types.ts: a list of system content hardcoded in a
+ * dialog silently drifts from the system it mirrors.
+ *
+ * The list that lived in the dialog was an *allow-list* — an effect was only
+ * offered if its id appeared in a hardcoded array — so it had drifted twice
+ * over. It offered `slowed` and `hasted`, which are not dnd5e conditions or
+ * statuses at all (they come from other modules, so those two entries never
+ * matched anything and were simply inert), while excluding twelve conditions
+ * dnd5e 5.3.3 really does define: `dehydration`, `falling`, `inaudible`,
+ * `malnutrition`, `suffocation`, `surprised` and `transformed`, plus the
+ * status-only `coverHalf` / `coverThreeQuarters` / `coverTotal`, `concentrating`
+ * and `dodging`.
+ *
+ * The fix is to treat the curated list as a *sort order* rather than a filter:
+ * the effects a trap most often applies float to the top, and everything else
+ * the system defines still appears below them. A new dnd5e condition then shows
+ * up on its own instead of waiting for someone to notice it is missing.
+ */
+
+/**
+ * Trap-relevant status effects, most to least common, used to order the head of
+ * the list. Ids not present in the running system are skipped, and system
+ * effects not named here are appended afterwards — so this array is safe to
+ * reorder or prune without ever removing an option from the dialog.
+ */
+const TRAP_EFFECT_PRIORITY: readonly string[] = [
+  'poisoned',
+  'restrained',
+  'prone',
+  'blinded',
+  'frightened',
+  'stunned',
+  'paralyzed',
+  'incapacitated',
+  'grappled',
+  'deafened',
+  'charmed',
+  'exhaustion',
+  'burning',
+  'bleeding',
+  'unconscious',
+  'petrified',
+  'cursed',
+  'diseased',
+  'silenced',
+  'suffocation',
+  'surprised',
+  'invisible',
+  'dead'
+];
+
+/**
+ * Effects that are bookkeeping rather than something a trap applies. Monk's
+ * Little Details registers combat-tracker markers this way, and dnd5e's own
+ * `concentrating` is managed by the system's concentration tracking — offering
+ * them as trap effects is noise.
+ */
+const EXCLUDED_EFFECT_IDS: readonly string[] = ['concentrating'];
+
+/** Effects whose id or label marks them as another module's internal tracking. */
+function isTrackingEffect(id: string, label: string): boolean {
+  return (
+    label.includes('MonksLittleDetails') ||
+    id.includes('monkslittledetails') ||
+    EXCLUDED_EFFECT_IDS.includes(id)
+  );
+}
+
+/**
+ * Status effects as `{ value, label }` pairs for the dialog templates.
+ *
+ * Reads `CONFIG.statusEffects`, which Foundry populates from the system —
+ * dnd5e 5.3.3 builds it from `CONFIG.DND5E.conditionTypes` plus its own
+ * status-only entries (cover levels, `flying`, `hiding`, and so on). Entries
+ * are returned in `TRAP_EFFECT_PRIORITY` order first, then every remaining
+ * system effect sorted by label so the tail is at least predictable.
+ */
+export function getStatusEffectOptions(): Array<{ value: string; label: string }> {
+  const statusEffects = (globalThis as any).CONFIG?.statusEffects;
+  if (!Array.isArray(statusEffects)) return [];
+
+  const byId = new Map<string, { value: string; label: string }>();
+  for (const effect of statusEffects) {
+    const id = String(effect?.id ?? effect?.name ?? '').toLowerCase();
+    if (!id) continue;
+
+    // `label` is the v11-era field and `name` the current one; dnd5e populates
+    // `name` and runs it through `preLocalize`, so it is already localized.
+    const label = String(effect?.name ?? effect?.label ?? '');
+    if (isTrackingEffect(id, label)) continue;
+
+    byId.set(id, { value: effect.id ?? effect.name, label: label || id });
+  }
+
+  const ordered: Array<{ value: string; label: string }> = [];
+  for (const id of TRAP_EFFECT_PRIORITY) {
+    const entry = byId.get(id);
+    if (entry) {
+      ordered.push(entry);
+      byId.delete(id);
+    }
+  }
+
+  const rest = [...byId.values()].sort((a, b) => a.label.localeCompare(b.label));
+  return [...ordered, ...rest];
+}

--- a/tests/utils/status-effects.test.ts
+++ b/tests/utils/status-effects.test.ts
@@ -145,6 +145,29 @@ describe('getStatusEffectOptions', () => {
     expect(ids).toEqual(['poisoned']);
   });
 
+  it('excludes action-economy and flanking markers, which a trap cannot meaningfully set', () => {
+    // All four appeared in the live dropdown and are cleared or recomputed by
+    // the module that owns them, so a trap setting one has no lasting effect.
+    setStatusEffects([
+      { id: 'poisoned', name: 'Poisoned' },
+      { id: 'bonusaction', name: 'Bonus Action used' },
+      { id: 'reaction', name: 'Reaction used' },
+      { id: 'flanking', name: 'Flanking' },
+      { id: 'flanked', name: 'Flanked' }
+    ]);
+    expect(getStatusEffectOptions().map(o => o.value)).toEqual(['poisoned']);
+  });
+
+  it('keeps marked and the encumbrance statuses, which are legitimate trap effects', () => {
+    setStatusEffects([
+      { id: 'marked', name: 'Marked' },
+      { id: 'encumbered', name: 'Encumbered' },
+      { id: 'heavilyEncumbered', name: 'Heavily Encumbered' },
+      { id: 'exceedingCarryingCapacity', name: 'Exceeding Carrying Capacity' }
+    ]);
+    expect(getStatusEffectOptions()).toHaveLength(4);
+  });
+
   it('does not offer slowed or hasted, which no dnd5e version defines', () => {
     mockDnd5eStatusEffects();
     const ids = getStatusEffectOptions().map(o => o.value);

--- a/tests/utils/status-effects.test.ts
+++ b/tests/utils/status-effects.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, afterEach } from '@jest/globals';
+import { getStatusEffectOptions } from '../../src/utils/helpers/status-effects';
+
+/**
+ * Verified against the live world on Foundry 14.364 / dnd5e 5.3.3 by reading
+ * `CONFIG.statusEffects` directly. The two lists below are what the system
+ * actually registers — `slowed` and `hasted` appear in neither, which is the
+ * bug this suite exists to prevent recurring.
+ */
+const DND5E_CONDITION_IDS = [
+  'bleeding',
+  'blinded',
+  'burning',
+  'charmed',
+  'cursed',
+  'deafened',
+  'dehydration',
+  'diseased',
+  'exhaustion',
+  'falling',
+  'frightened',
+  'grappled',
+  'inaudible',
+  'incapacitated',
+  'invisible',
+  'malnutrition',
+  'paralyzed',
+  'petrified',
+  'poisoned',
+  'prone',
+  'restrained',
+  'silenced',
+  'stunned',
+  'suffocation',
+  'surprised',
+  'transformed',
+  'unconscious'
+];
+
+const DND5E_STATUS_ONLY_IDS = [
+  'burrowing',
+  'concentrating',
+  'coverHalf',
+  'coverThreeQuarters',
+  'coverTotal',
+  'dead',
+  'dodging',
+  'ethereal',
+  'flying',
+  'hiding',
+  'hovering',
+  'marked',
+  'sleeping',
+  'stable',
+  'encumbered',
+  'heavilyEncumbered'
+];
+
+function setStatusEffects(entries: Array<{ id: string; name?: string; label?: string }>): void {
+  (globalThis as any).CONFIG = { statusEffects: entries };
+}
+
+function mockDnd5eStatusEffects(): void {
+  setStatusEffects(
+    [...DND5E_CONDITION_IDS, ...DND5E_STATUS_ONLY_IDS].map(id => ({
+      id,
+      // dnd5e runs these through `preLocalize`, so they arrive already localized.
+      name: id.charAt(0).toUpperCase() + id.slice(1)
+    }))
+  );
+}
+
+describe('getStatusEffectOptions', () => {
+  const originalConfig = (globalThis as any).CONFIG;
+
+  afterEach(() => {
+    (globalThis as any).CONFIG = originalConfig;
+  });
+
+  it('returns an empty list when the system has not populated CONFIG.statusEffects', () => {
+    (globalThis as any).CONFIG = {};
+    expect(getStatusEffectOptions()).toEqual([]);
+  });
+
+  it('offers every dnd5e 5.3.3 condition, including the twelve the old allow-list dropped', () => {
+    mockDnd5eStatusEffects();
+    const ids = getStatusEffectOptions().map(o => o.value);
+
+    // The regression: these are real conditions that the hardcoded allow-list
+    // filtered out, so a GM could not build a trap that applied them.
+    for (const id of [
+      'dehydration',
+      'falling',
+      'inaudible',
+      'malnutrition',
+      'suffocation',
+      'surprised',
+      'transformed'
+    ]) {
+      expect(ids).toContain(id);
+    }
+
+    // And the cover levels, which are status-only rather than conditions.
+    expect(ids).toContain('coverHalf');
+    expect(ids).toContain('coverThreeQuarters');
+    expect(ids).toContain('coverTotal');
+  });
+
+  it('never drops a system-defined effect', () => {
+    mockDnd5eStatusEffects();
+    const ids = getStatusEffectOptions().map(o => o.value);
+    // Every condition survives; only deliberate exclusions may be absent.
+    for (const id of DND5E_CONDITION_IDS) {
+      expect(ids).toContain(id);
+    }
+  });
+
+  it('orders the trap-relevant effects first, in priority order', () => {
+    mockDnd5eStatusEffects();
+    const ids = getStatusEffectOptions().map(o => o.value);
+
+    expect(ids[0]).toBe('poisoned');
+    expect(ids.indexOf('poisoned')).toBeLessThan(ids.indexOf('restrained'));
+    expect(ids.indexOf('restrained')).toBeLessThan(ids.indexOf('prone'));
+    // A non-prioritised effect sorts after every prioritised one.
+    expect(ids.indexOf('dead')).toBeLessThan(ids.indexOf('coverHalf'));
+  });
+
+  it('sorts the non-prioritised tail by label', () => {
+    mockDnd5eStatusEffects();
+    const options = getStatusEffectOptions();
+    const tail = options.slice(options.findIndex(o => o.value === 'dead') + 1);
+    const labels = tail.map(o => o.label);
+    expect(labels).toEqual([...labels].sort((a, b) => a.localeCompare(b)));
+  });
+
+  it('excludes other modules’ combat-tracker bookkeeping', () => {
+    setStatusEffects([
+      { id: 'poisoned', name: 'Poisoned' },
+      { id: 'monkslittledetails-turn', name: 'Turn Marker' },
+      { id: 'mld', name: 'MonksLittleDetails Marker' },
+      { id: 'concentrating', name: 'Concentrating' }
+    ]);
+    const ids = getStatusEffectOptions().map(o => o.value);
+    expect(ids).toEqual(['poisoned']);
+  });
+
+  it('does not offer slowed or hasted, which no dnd5e version defines', () => {
+    mockDnd5eStatusEffects();
+    const ids = getStatusEffectOptions().map(o => o.value);
+    expect(ids).not.toContain('slowed');
+    expect(ids).not.toContain('hasted');
+  });
+
+  it('passes through an effect another module legitimately registers', () => {
+    // The flip side of the above: the list is no longer an allow-list, so a
+    // module that registers a real status effect gets it offered.
+    setStatusEffects([
+      { id: 'poisoned', name: 'Poisoned' },
+      { id: 'slowed', name: 'Slowed' }
+    ]);
+    expect(getStatusEffectOptions().map(o => o.value)).toContain('slowed');
+  });
+
+  it('falls back to the v11-era label field and then to the id', () => {
+    setStatusEffects([{ id: 'poisoned', label: 'Poisoned (legacy)' }, { id: 'nameless' } as any]);
+    const options = getStatusEffectOptions();
+    expect(options.find(o => o.value === 'poisoned')?.label).toBe('Poisoned (legacy)');
+    expect(options.find(o => o.value === 'nameless')?.label).toBe('nameless');
+  });
+});


### PR DESCRIPTION
## The bug

The trap dialog built its effect dropdown by filtering `CONFIG.statusEffects` against a hardcoded array, and the filter was an **allow-list** — an effect whose id was not written into that array was dropped from the dialog entirely.

It had drifted in both directions.

**Twelve real dnd5e 5.3.3 conditions could not be selected:** `dehydration`, `falling`, `inaudible`, `malnutrition`, `suffocation`, `surprised`, `transformed`, the three cover levels (`coverHalf`, `coverThreeQuarters`, `coverTotal`), plus `dodging`. A GM building a suffocation trap or a rockfall that grants cover simply had no option for it.

**Two entries pointed at nothing:** `slowed` and `hasted` are not dnd5e conditions or statuses — they come from other modules. Those two array entries never matched, so they were inert rather than broken, but they are why the list looked complete.

## The fix

Move the list to `src/utils/helpers/status-effects.ts`, mirroring the shape `damage-types.ts` already uses for the same reason, and **demote the curated array from a filter to a sort order**. The trap-relevant effects still lead the list in a deliberate order; everything else the system defines now follows, sorted by label.

The list can no longer silently drift. A condition added by a future dnd5e release, or registered by another module, appears on its own — and `slowed`/`hasted` will show up correctly for anyone who actually has the module that provides them.

A short **deny**-list stays, and the asymmetry is deliberate: it fails toward showing an unrecognised effect, where the allow-list failed toward hiding one. It holds only effects a trap applying would be meaningless: dnd5e's `concentrating` (system-managed), `bonusaction`/`reaction` (action-economy markers cleared every turn), and `flanking`/`flanked` (recomputed from token positions). `marked` and dnd5e's encumbrance statuses are deliberately kept — those are plausible trap effects.

## Verification

`typecheck → lint → format:check → build` all clean. **1051 tests, 30 suites**, 11 of them new.

**Live-verified on Foundry 14.364 / dnd5e 5.3.3**, by opening the real trap dialog, switching Result Type to "Add Active Effect", and reading the rendered `<select>`:

- Before the deny-list refinement: **47 options** (up from 22), priority head in the intended order, tail correctly sorted by label, all twelve previously-missing conditions present, `slowed`/`hasted` absent.
- After: **43 options**, all five bookkeeping ids absent, `marked` and the encumbrance statuses retained.

The condition ids in the test suite are transcribed from that same live `CONFIG.statusEffects` rather than from documentation, which is how the twelve missing conditions were identified in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)